### PR TITLE
Update deprecated array syntax

### DIFF
--- a/inst/stan/functions/calc_loglik.stan
+++ b/inst/stan/functions/calc_loglik.stan
@@ -5,14 +5,14 @@ vector calc_loglik_dna(
   int n_S,
   int S_dna,
   int Nloc_dna,
-  int[] n_K,
-  int[] n_N,
+  array[] int n_K,
+  array[] int n_N,
   vector p_trad,
-  int[] L_ind,
-  int[] K_dna,
-  int[] N_dna,
-  real[] p_dna,
-  int[] L_dna){
+  array[] int L_ind,
+  array[] int K_dna,
+  array[] int N_dna,
+  array[] real p_dna,
+  array[] int L_dna){
 
     vector[n_S + S_dna] log_lik;
 
@@ -32,10 +32,10 @@ vector calc_loglik_dna(
 
 // calculate log likelihood of traditional count data
 vector calc_loglik_trad_count(
-  real[] lambda,
+  array[] real lambda,
   int negbin,
-  real[] phi,
-  int[] n_E,
+  array[] real phi,
+  array[] int n_E,
   int n_C){
 
     vector[n_C] log_lik;
@@ -55,10 +55,10 @@ vector calc_loglik_trad_count(
 
 // calculate log likelihood of traditional continuous data
 vector calc_loglik_trad_continuous(
-  real[] lambda,
+  array[] real lambda,
   vector beta_gamma,
-  real[] E_trans,
-  int[] R_ind,
+  array[] real E_trans,
+  array[] int R_ind,
   int n_C){
 
     vector[n_C] log_lik;
@@ -74,30 +74,30 @@ vector calc_loglik_trad_continuous(
 // calculate log likelihood of data in joint count model
 vector calc_loglik_count(
   int ctch,
-  real[] coef,
-  int[] mat,
+  array[] real coef,
+  array[] int mat,
   vector mu_trad,
-  int[] R_ind,
+  array[] int R_ind,
   int negbin,
-  real[] phi,
-  int[] n_E,
-  int[] n_K,
-  int[] n_N,
+  array[] real phi,
+  array[] int n_E,
+  array[] int n_K,
+  array[] int n_N,
   vector p_trad,
-  int[] L_ind,
+  array[] int L_ind,
   int n_C,
   int n_S,
   int S_dna,
   int Nloc_dna,
-  int[] K_dna,
-  int[] N_dna,
-  real[] p_dna,
-  int[] L_dna){
+  array[] int K_dna,
+  array[] int N_dna,
+  array[] real p_dna,
+  array[] int L_dna){
 
     vector[n_C + n_S + S_dna] log_lik;
 
     // get lambda
-    real lambda[n_C];
+    array[n_C] real lambda;
     lambda = get_lambda_count(ctch, coef, mat, mu_trad, R_ind, n_C);
 
     // traditional data
@@ -117,29 +117,29 @@ vector calc_loglik_count(
 // calculate log likelihood of data in joint continuous model
 vector calc_loglik_continuous(
   int ctch,
-  real[] coef,
-  int[] mat,
+  array[] real coef,
+  array[] int mat,
   vector alpha_gamma,
   vector beta_gamma,
-  int[] R_ind,
-  real[] E_trans,
-  int[] n_K,
-  int[] n_N,
+  array[] int R_ind,
+  array[] real E_trans,
+  array[] int n_K,
+  array[] int n_N,
   vector p_trad,
-  int[] L_ind,
+  array[] int L_ind,
   int n_C,
   int n_S,
   int S_dna,
   int Nloc_dna,
-  int[] K_dna,
-  int[] N_dna,
-  real[] p_dna,
-  int[] L_dna){
+  array[] int K_dna,
+  array[] int N_dna,
+  array[] real p_dna,
+  array[] int L_dna){
 
     vector[n_C+n_S+S_dna] log_lik;
 
     // get lambda
-    real lambda[n_C];
+    array[n_C] real lambda;
     lambda = get_lambda_continuous(ctch, coef, mat, alpha_gamma, R_ind, n_C);
 
     // traditional data
@@ -158,15 +158,15 @@ vector calc_loglik_continuous(
   }
 
 // calculate lambda for count data
-real[] get_lambda_count(
+array[] real get_lambda_count(
   int ctch,
-  real[] coef,
-  int[] mat,
+  array[] real coef,
+  array[] int mat,
   vector mu_trad,
-  int[] R_ind,
+  array[] int R_ind,
   int n_C){
 
-    real lambda[n_C];
+    array[n_C] real lambda;
 
     for (j in 1:n_C) {
       lambda[j] = (
@@ -178,15 +178,15 @@ real[] get_lambda_count(
 }
 
 // calculate lambda for continuous data
-real[] get_lambda_continuous(
+array[] real get_lambda_continuous(
   int ctch,
-  real[] coef,
-  int[] mat,
+  array[] real coef,
+  array[] int mat,
   vector alpha_gamma,
-  int[] R_ind,
+  array[] int R_ind,
   int n_C){
 
-    real lambda[n_C];
+    array[n_C] real lambda;
 
     for (j in 1:n_C) {
       lambda[j] = (
@@ -201,19 +201,19 @@ real[] get_lambda_continuous(
 // calculate log likelihood of data in traditional count model
 vector calc_loglik_tradmod_count(
   int negbin,
-  real[] phi,
-  int[] n_E,
+  array[] real phi,
+  array[] int n_E,
   int n_C,
   int ctch,
-  real[] coef,
-  int[] mat,
+  array[] real coef,
+  array[] int mat,
   vector mu_1,
-  int[] R_ind){
+  array[] int R_ind){
 
     vector[n_C] log_lik;
 
     //get lambda
-    real lambda[n_C];
+    array[n_C] real lambda;
     lambda = get_lambda_count(ctch, coef, mat, mu_1, R_ind, n_C);
 
     //store log likelihood of traditional data given model
@@ -225,18 +225,18 @@ vector calc_loglik_tradmod_count(
 // calculate log likelihood of data in traditional continuous model
 vector calc_loglik_tradmod_continuous(
   vector beta,
-  real[] E_trans,
-  int[] R_ind,
+  array[] real E_trans,
+  array[] int R_ind,
   int n_C,
   int ctch,
-  real[] coef,
-  int[] mat,
+  array[] real coef,
+  array[] int mat,
   vector alpha){
 
     vector[n_C] log_lik;
 
     //get lambda
-    real lambda[n_C];
+    array[n_C] real lambda;
     lambda = get_lambda_continuous(ctch, coef, mat, alpha, R_ind, n_C);
 
     //store log likelihood of traditional data given model

--- a/inst/stan/functions/calc_mu.stan
+++ b/inst/stan/functions/calc_mu.stan
@@ -2,15 +2,15 @@
 
 // calculate mu for joint models
 matrix calc_mu(
-  int[] trad_ind,
-  int[] dna_ind,
+  array[] int trad_ind,
+  array[] int dna_ind,
   vector mu_trad,
   int ctch,
   int nparams,
   vector q,
   int Nloc_dna,
   int Nloc_trad,
-  real[] p_dna,
+  array[] real p_dna,
   real p10,
   matrix mat_site,
   vector alpha){
@@ -24,7 +24,7 @@ matrix calc_mu(
 
     if (Nloc_dna > 0) {
       for (i in 1:Nloc_dna) {
-        real p11_dna[Nloc_dna];
+        array[Nloc_dna] real p11_dna;
         p11_dna[i] = p_dna[i] - p10;
         mu[dna_ind[i], 1] = (
           p11_dna[i]*exp(dot_product(to_vector(mat_site[dna_ind[i]]), alpha)) /

--- a/inst/stan/functions/calc_p11.stan
+++ b/inst/stan/functions/calc_p11.stan
@@ -5,7 +5,7 @@ vector calc_p11(
   int Nloc_trad,
   vector mu_trad,
   matrix mat_site,
-  int[] trad_ind,
+  array[] int trad_ind,
   vector alpha){
 
     vector[Nloc_trad] p11_trad;

--- a/inst/stan/joint_continuous.stan
+++ b/inst/stan/joint_continuous.stan
@@ -76,7 +76,7 @@ transformed parameters {
   // total detection probability
   vector<lower=0, upper = 1>[Nloc_trad] p_trad;
   // traditional sample-specific catchability coefficient
-  real<lower=0> coef[(ctch == 1) ? nparams + 1 : 0];
+  array[(ctch == 1) ? nparams + 1 : 0] real<lower=0> coef;
   // expected catch at each site for sites with traditional samples
   vector<lower=0>[Nloc_trad] mu_trad;
   // transformed traditional data so that E > 0
@@ -97,7 +97,7 @@ transformed parameters {
 
 model {
   // get lambda
-  real lambda[n_C];
+  array[n_C] real lambda;
   lambda = get_lambda_continuous(ctch, coef, mat, alpha_gamma, R_ind, n_C);
 
   for (j in 1:n_C) {

--- a/inst/stan/joint_count.stan
+++ b/inst/stan/joint_count.stan
@@ -67,7 +67,7 @@ parameters {
   // site-level beta covariates
   vector[nsitecov] alpha;
   // dispersion parameter
-  real<lower = 0> phi[(negbin == 1) ? 1 :  0];
+  array[(negbin == 1) ? 1 :  0] real<lower = 0> phi;
 }
 
 transformed parameters {
@@ -76,7 +76,7 @@ transformed parameters {
   // total detection probability
   vector<lower = 0, upper = 1>[Nloc_trad] p_trad;
   // traditional sample-specific catchability coefficient
-  real<lower = 0> coef[(ctch == 1) ? nparams + 1 : 0];
+  array[(ctch == 1) ? nparams + 1 : 0] real<lower = 0> coef;
 
   p11_trad = calc_p11(Nloc_trad, mu_trad, mat_site, trad_ind, alpha); // Eq. 1.2
   p_trad = p11_trad + exp(log_p10); // Eq. 1.3
@@ -88,7 +88,7 @@ transformed parameters {
 
 model {
   // get lambda
-  real lambda[n_C];
+  array[n_C] real lambda;
   lambda = get_lambda_count(ctch, coef, mat, mu_trad, R_ind, n_C);
 
   if (negbin == 1) {

--- a/inst/stan/traditional_continuous.stan
+++ b/inst/stan/traditional_continuous.stan
@@ -35,7 +35,7 @@ parameters {
 
 transformed parameters {
   // traditional sample-specific catchability coefficient
-  real<lower = 0> coef[(ctch == 1) ? nparams + 1 :  0];
+  array[(ctch == 1) ? nparams + 1 :  0] real<lower = 0> coef;
   // transformed traditional data so that E > 0
   array[n_C] real<lower = 0> E_trans;
 
@@ -50,7 +50,7 @@ transformed parameters {
 
 model {
   // get lambda
-  real lambda[n_C];
+  array[n_C] real lambda;
   lambda = get_lambda_continuous(ctch, coef, mat, alpha, R_ind, n_C);
 
   for (j in 1:n_C) {

--- a/inst/stan/traditional_count.stan
+++ b/inst/stan/traditional_count.stan
@@ -28,13 +28,13 @@ parameters {
   // expected density at each site
   vector<lower = 0>[Nloc] mu_1;
   // dispersion parameter
-  real<lower = 0> phi[(negbin == 1) ? 1 : 0];
+  array[(negbin == 1) ? 1 : 0] real<lower = 0> phi;
   // catchability coefficients
   vector<lower = -0.99999>[nparams] q_trans;
 }
 
 transformed parameters {
-  real<lower = 0> coef[(ctch == 1) ? nparams + 1 : 0];
+  array[(ctch == 1) ? nparams + 1 : 0] real<lower = 0> coef;
 
   if (ctch == 1) {
     coef = to_array_1d(append_row(1, 1 + q_trans));
@@ -44,7 +44,7 @@ transformed parameters {
 
 model {
   // get lambda
-  real lambda[n_C];
+  array[n_C] real lambda;
   lambda = get_lambda_count(ctch, coef, mat, mu_1, R_ind, n_C);
 
   if (negbin == 1) {


### PR DESCRIPTION
This PR updates the Stan models in your package to replace the deprecated array syntax, otherwise it will fail to compile with newer versions of RStan.

Let me know if you have any questions, thanks!